### PR TITLE
feat: add command-line options

### DIFF
--- a/mkchimeenv.py
+++ b/mkchimeenv.py
@@ -21,7 +21,7 @@ from virtualenvapi.manage import VirtualEnvironment
 __version__ = "2022.06"
 
 
-chime_repositories = {
+public_repositories = {
     # radio cosmology packages
     "caput": ("ssh://git@github.com/radiocosmology/caput", None),
     "cora": ("ssh://git@github.com/radiocosmology/cora", None),
@@ -29,7 +29,6 @@ chime_repositories = {
     "draco": ("ssh://git@github.com/radiocosmology/draco", None),
     # chimedb core code and extensions
     "chimedb": ("ssh://git@github.com/chime-experiment/chimedb", None),
-    "chimedb-config": ("ssh://git@github.com/chime-experiment/chimedb_config", None),
     "chimedb-data_index": ("ssh://git@github.com/chime-experiment/chimedb_di", None),
     "chimedb-dataflag": (
         "ssh://git@github.com/chime-experiment/chimedb_dataflag",
@@ -39,6 +38,10 @@ chime_repositories = {
     # chime specific repositories
     "ch_util": ("ssh://git@github.com/chime-experiment/ch_util", None),
     "ch_pipeline": ("ssh://git@github.com/chime-experiment/ch_pipeline", None),
+}
+
+private_repositories = {
+    "chimedb-config": ("ssh://git@github.com/chime-experiment/chimedb_config", None),
 }
 
 # At the moment this script struggles to determine extra requirements and so I just list
@@ -164,10 +167,20 @@ def install_multiple(
     "--download/--no-download", default=True, help="Download the skyfield data."
 )
 @click.option(
-    "--ignore-system-packages", is_flag=True, help="Ignore system site packages"
+    "--ignore-system-packages", is_flag=True, help="Ignore system site packages."
+)
+@click.option(
+    "--chime-member/--non-chime-member",
+    default=True,
+    help="Whether to include private CHIME repositories.",
 )
 def create(
-    path: Path, prompt: str, fast: bool, download: bool, ignore_system_packages: bool
+    path: Path,
+    prompt: str,
+    fast: bool,
+    download: bool,
+    ignore_system_packages: bool,
+    chime_member: bool,
 ):
     """Install a CHIME pipeline environment at the specified PATH.
 
@@ -205,6 +218,12 @@ def create(
     env = VirtualEnvironment(str(venv_path))
     console.print("Upgrading pip")
     env.upgrade("pip")
+
+    # Determine which repositories to close
+    if chime_member:
+        chime_repositories = {**public_repositories, **private_repositories}
+    else:
+        chime_repositories = public_repositories
 
     # Clone the CHIME repos and extract their dependencies
     console.rule("Cloning CHIME repositories")

--- a/mkchimeenv.py
+++ b/mkchimeenv.py
@@ -21,27 +21,42 @@ from virtualenvapi.manage import VirtualEnvironment
 __version__ = "2022.06"
 
 
-public_repositories = {
-    # radio cosmology packages
-    "caput": ("ssh://git@github.com/radiocosmology/caput", None),
-    "cora": ("ssh://git@github.com/radiocosmology/cora", None),
-    "driftscan": ("ssh://git@github.com/radiocosmology/driftscan", None),
-    "draco": ("ssh://git@github.com/radiocosmology/draco", None),
-    # chimedb core code and extensions
-    "chimedb": ("ssh://git@github.com/chime-experiment/chimedb", None),
-    "chimedb-data_index": ("ssh://git@github.com/chime-experiment/chimedb_di", None),
-    "chimedb-dataflag": (
-        "ssh://git@github.com/chime-experiment/chimedb_dataflag",
-        None,
-    ),
-    "chimedb-dataset": ("ssh://git@github.com/chime-experiment/chimedb_dataset", None),
-    # chime specific repositories
-    "ch_util": ("ssh://git@github.com/chime-experiment/ch_util", None),
-    "ch_pipeline": ("ssh://git@github.com/chime-experiment/ch_pipeline", None),
-}
+def _clone_path(repo, ssh=True):
+    if ssh:
+        return f"ssh://git@github.com/{repo}"
+    else:
+        return f"https://github.com/{repo}.git"
+
+
+def public_repositories(ssh=True):
+    return {
+        # radio cosmology packages
+        "caput": (_clone_path("radiocosmology/caput", ssh=ssh), None),
+        "cora": (_clone_path("radiocosmology/cora", ssh=ssh), None),
+        "driftscan": (_clone_path("radiocosmology/driftscan", ssh=ssh), None),
+        "draco": (_clone_path("radiocosmology/draco", ssh=ssh), None),
+        # chimedb core code and extensions
+        "chimedb": (_clone_path("chime-experiment/chimedb", ssh=ssh), None),
+        "chimedb-data_index": (
+            _clone_path("chime-experiment/chimedb_di", ssh=ssh),
+            None,
+        ),
+        "chimedb-dataflag": (
+            _clone_path("chime-experiment/chimedb_dataflag", ssh=ssh),
+            None,
+        ),
+        "chimedb-dataset": (
+            _clone_path("chime-experiment/chimedb_dataset", ssh=ssh),
+            None,
+        ),
+        # chime specific repositories
+        "ch_util": (_clone_path("chime-experiment/ch_util", ssh=ssh), None),
+        "ch_pipeline": (_clone_path("chime-experiment/ch_pipeline", ssh=ssh), None),
+    }
+
 
 private_repositories = {
-    "chimedb-config": ("ssh://git@github.com/chime-experiment/chimedb_config", None),
+    "chimedb-config": (_clone_path("chime-experiment/chimedb_config", ssh=True), None),
 }
 
 # At the moment this script struggles to determine extra requirements and so I just list
@@ -221,9 +236,9 @@ def create(
 
     # Determine which repositories to close
     if chime_member:
-        chime_repositories = {**public_repositories, **private_repositories}
+        chime_repositories = {**public_repositories(ssh=True), **private_repositories}
     else:
-        chime_repositories = public_repositories
+        chime_repositories = public_repositories(ssh=False)
 
     # Clone the CHIME repos and extract their dependencies
     console.rule("Cloning CHIME repositories")

--- a/mkchimeenv.py
+++ b/mkchimeenv.py
@@ -109,7 +109,6 @@ class RichProgress(git.RemoteProgress):
         self.tasks: dict[int, int] = {}
 
     def update(self, op_code, cur_count, max_count=None, message=""):
-
         code, msg, done = match_opcode(op_code)
 
         if code not in self.tasks:
@@ -145,7 +144,6 @@ def install_multiple(
 
     # Use a temporary requirements file and then use the usual `env.install`
     with tempfile.NamedTemporaryFile(mode="w+", delete=False) as tfh:
-
         for pkg in packages:
             tfh.write(f"{pkg}\n")
 
@@ -165,7 +163,12 @@ def install_multiple(
 @click.option(
     "--download/--no-download", default=True, help="Download the skyfield data."
 )
-def create(path: Path, prompt: str, fast: bool, download: bool):
+@click.option(
+    "--ignore-system-packages", is_flag=True, help="Ignore system site packages"
+)
+def create(
+    path: Path, prompt: str, fast: bool, download: bool, ignore_system_packages: bool
+):
     """Install a CHIME pipeline environment at the specified PATH.
 
     This will create a virtualenvironment and make editable installs of all the CHIME
@@ -195,7 +198,7 @@ def create(path: Path, prompt: str, fast: bool, download: bool):
     else:
         venv.create(
             venv_path,
-            system_site_packages=True,
+            system_site_packages=not ignore_system_packages,
             with_pip=True,
             prompt=prompt,
         )
@@ -216,7 +219,6 @@ def create(path: Path, prompt: str, fast: bool, download: bool):
         console=console,
     ) as progress:
         for label, (name, (url, target)) in labeller(chime_repositories.items()):
-
             clone_path = code_path / name
 
             git.Repo.clone_from(
@@ -274,7 +276,6 @@ def create(path: Path, prompt: str, fast: bool, download: bool):
         *Progress.get_default_columns()[:-1],
         console=console,
     ) as progress:
-
         for label, (reqname, reqs) in labeller(req_dict.items()):
             task = progress.add_task(f"{label} {reqname}", total=None)
 
@@ -298,9 +299,7 @@ def create(path: Path, prompt: str, fast: bool, download: bool):
         *Progress.get_default_columns()[:-1],
         console=console,
     ) as progress:
-
         for label, chime_package in labeller(chime_repo_names):
-
             task = progress.add_task(
                 f"{label} {chime_package}",
                 total=None,

--- a/mkchimeenv.py
+++ b/mkchimeenv.py
@@ -18,7 +18,7 @@ from requirements_detector.requirement import DetectedRequirement
 from virtualenvapi.manage import VirtualEnvironment
 
 
-__version__ = "2022.06"
+__version__ = "2023.05"
 
 
 def _clone_path(repo, ssh=True):


### PR DESCRIPTION
This adds 2 options:
1. `--ignore-system-packages`, so the user can choose to ignore system site packages (which could be useful for avoiding conflicts or oddities in the user's base Python environment)
2. `--non-chime-member`, which omits `chimedb-config` from the list of repositories and should therefore allow the user to create the environment without being a member of the CHIME GitHub organization.

If we make this repository public, these changes (along with the existing behavior of `mkchimeenv`) should completely address my list of grievances about ch_pipeline's `mkvenv.sh` script (see https://github.com/chime-experiment/ch_pipeline/pull/193).

I'm going to leave this as a draft until I can test it a bit more on a few other machines.