### PR TITLE
Option to use legacy mode `compat` for editable installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,12 @@ can sometimes be useful for avoiding conflicts with your existing Python setup.
 
 To speed up the creation you can use the `--fast` option to the create command.
 This will turn off build isolation when pip is installing the packages, which
-will give a large speed boost (especially on cedar), but may be less robust.
+will give a large speed boost (especially on cedar), but may be less robust. This option
+generally does not work on macOS.
+
+When using language tools such as Pylance (which is generally enabled by default in
+VSCode) or other type-checkers, the `--compat` flag should be used. The CHIME libraries
+are installed in editable mode, and recent updates to setuptools will break language
+tools ability to find the source files associated with any packages installed in
+editable mode. This flag enables legacy editable install behaviour, allowing Pylance
+and other tools to work correctly.

--- a/mkchimeenv.py
+++ b/mkchimeenv.py
@@ -181,6 +181,7 @@ def install_multiple(
 @click.option(
     "--fast", is_flag=True, help="Turn on some speedups that could break the install."
 )
+@click.option("--compat", is_flag=True, help="Use legacy editable install mode.")
 @click.option(
     "--download/--no-download", default=True, help="Download the skyfield data."
 )
@@ -196,6 +197,7 @@ def create(
     path: Path,
     prompt: str,
     fast: bool,
+    compat: bool,
     download: bool,
     ignore_system_packages: bool,
     chime_member: bool,
@@ -345,6 +347,8 @@ def create(
             options = ["--no-deps"]
             if fast:
                 options += ["--no-build-isolation"]
+            if compat:
+                options += ["--config-settings", "editable_mode=compat"]
             env.install(f"-e {code_path / chime_package}", options=options)
             progress.reset(task, total=1, completed=1)
 


### PR DESCRIPTION
[Changes](https://setuptools.pypa.io/en/latest/userguide/development_mode.html#legacy-behavior) to the way `setuptools` handles editable installs breaks `pylance`'s ability to resolve these imports. I haven't tested with other linters but I assume there are similar issues. 

See Pylance troubleshooting: https://github.com/microsoft/pylance-release/blob/main/TROUBLESHOOTING.md#editable-install-modules-not-found

The PR adds a flag to use `compat` mode with editable installs, which enables legacy behaviour and resolves the `Pylance` issues. 