### PR TITLE
Use forked requirements-detector to properly read from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ license = {file = "LICENSE"}
 readme = "README.md"
 classifiers = ["License :: OSI Approved :: MIT License"]
 dynamic = ["version", "description"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    "requirements-detector",
+    "requirements-detector @ git+https://github.com/ljgray/requirements-detector.git",
     "virtualenv",
     "virtualenv-api",
     "GitPython",


### PR DESCRIPTION
Use a fork of `requirements-detector`. This maybe isn't a perfect fix, but I think it's fine for the time being. I've verified that this works on Cedar.

Fork is here https://github.com/ljgray/requirements-detector